### PR TITLE
fixing resultTag

### DIFF
--- a/lib/api-list.js
+++ b/lib/api-list.js
@@ -1,6 +1,6 @@
 module.exports = {
   GetDeepSearchResults: {
-    resultTag: "Searchresults:searchresults",
+    resultTag: "SearchResults:searchresults",
     requiredParams: ["address", "citystatezip"]
   },
   GetUpdatedPropertyDetails: {

--- a/lib/node-zillow.js
+++ b/lib/node-zillow.js
@@ -73,7 +73,7 @@ Zillow.prototype.getDemographics = function(params) {
   var paramsString = helpers.toQueryString(params, this.id);
 
   var requestUrl = rootUrl + 'GetDemographics.htm?' + paramsString;
-  
+
   return helpers.httprequest(requestUrl)
     .then(helpers.toJson)
     .then(function(results) {


### PR DESCRIPTION
I tested all of the APIs listed in `api-list.js`. All of them worked great except for `GetDeepSearchResults` because of the incorrect resultTag. I stared at this for a while until I finally figured it out. The lowercase was obscure. 