### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,6 @@ This module uses promises via the Q library.  Please continue to use promises. A
 
 ## License
 Copyright (c) 2016 Richard Lucas. Licensed under the MIT license.
+
+For testing pruposes, you can visit [RapidAPI](https://rapidapi.com/package/Zillow/functions?utm_source=ZillowGitHub&utm_medium=button)
+


### PR DESCRIPTION
Hey! I've added a link in your README to Zillow's functions page in RapidAPI. I've done this for a few Zillow SDKs to help those who are reading the READMEs, understand and test the API before use.