### PR TITLE
Added reviews api

### DIFF
--- a/lib/api-list.js
+++ b/lib/api-list.js
@@ -46,5 +46,9 @@ module.exports = {
   GetComps: {
     resultTag: "Comps:comps",
     requiredParams: ["zpid", "count"]
+  },
+  ProReviews: {
+    resultTag: "Reviews:reviews",
+    requiredParams: ["screenname"]
   }
 };


### PR DESCRIPTION
Zillow has added the ability to get individual agent reviews from their API, which would be helpful to developers when creating real estate sites and want a quick/easy way to add review functionality.